### PR TITLE
go.mod: rename module to fork name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/christarazi/controller-tools
+module github.com/cilium/controller-tools
 
 go 1.13
 


### PR DESCRIPTION
This will allow to use the module in the main Cilium repository without using replace directives in go.mod.

/cc @christarazi @aanm